### PR TITLE
Troca da palavra horas por créditos

### DIFF
--- a/js/ui_combinacoes.js
+++ b/js/ui_combinacoes.js
@@ -35,7 +35,7 @@ function UI_combinacoes(id)
         button.ondblclick = function () { self.cb_next(); };
     }
     d2.appendChild(button);
-    d2.appendChild(document.createTextNode(" Horas por semana: "));
+    d2.appendChild(document.createTextNode(" Créditos por semana: "));
     var horas_aula = document.createTextNode("0");
     d2.appendChild(horas_aula);
 


### PR DESCRIPTION
A palavra horas (mesmo que referindo-se a horas aula) pode confundir os estudantes. A simples troca pela palavra créditos pode facilitar o entendimento.
