### PR TITLE
Fix matrufsc save feature

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -694,13 +694,14 @@ function Main(ui_materias, ui_turmas, ui_logger, ui_combinacoes, ui_horario,
                         'erro ao salvar horário para "' + identifier + '"',
                         'lightcoral'
                     );
+                } else {
+                    ui_logger.set_text(
+                        'horário para "' + identifier + '" foi salvo',
+                        'lightgreen'
+                    );
+                    persistence.write_id(identifier);
+                    mudancas = false;
                 }
-                ui_logger.set_text(
-                    'horário para "' + identifier + '" foi salvo',
-                    'lightgreen'
-                );
-                persistence.write_id(identifier);
-                mudancas = false;
             });
 
         _gaq.push(['_trackEvent', 'state', 'save', identifier])

--- a/py/capim.py
+++ b/py/capim.py
@@ -36,8 +36,8 @@ def get_q(qs):
     raise IOError
 
 
-def encoded_fname(environ):
-    return get_q(environ['QUERY_STRING']).encode('hex') + '.json'
+def encoded_fname(identifier):
+    return identifier.encode('utf-8').hex() + '.json'
 
 
 def run(environ, start_response):
@@ -106,7 +106,7 @@ def run(environ, start_response):
         start_response('200 OK', headers)
         return [content]
 
-    elif path0 == 'load2.cgi':
+    elif path0 == 'load':
         fname = encoded_fname(environ)
         data = None
         headers = [('Content-Type', 'application/json'), ('Expires', '-1')]
@@ -126,16 +126,22 @@ def run(environ, start_response):
             data = ''
         start_response('200 OK', headers)
         return [data]
-    elif path0 == 'save2.cgi':
-        fname = encoded_fname(environ)
-        data = environ['wsgi.input'].read()
+    elif path0 == 'store':
+        fname = encoded_fname(path[1])
+        try:
+            request_body_size = int(environ.get('CONTENT_LENGTH', 0))
+        except (ValueError):
+            request_body_size = 0
+            
+        data = environ['wsgi.input'].read(request_body_size)
+
         with gzip.open(DATA_PREFIX + fname + '.gz', 'wb') as fp:
             fp.write(data)
         start_response(
             '200 OK',
             [('Content-Type', 'text/html'), ('Expires', '-1')]
         )
-        return ['OK']
+        return [b'OK']
     elif path0 == 'ping.cgi':
         content_disposition = (
             f'attachment; filename={get_q(environ["QUERY_STRING"])}'

--- a/py/capim.py
+++ b/py/capim.py
@@ -107,7 +107,7 @@ def run(environ, start_response):
         return [content]
 
     elif path0 == 'load':
-        fname = encoded_fname(environ)
+        fname = encoded_fname(path[1])
         data = None
         headers = [('Content-Type', 'application/json'), ('Expires', '-1')]
         try:


### PR DESCRIPTION
Esta alteração implementa uma refatoração nos mecanismos de persistência, tanto no frontend (JavaScript) quanto no backend (Python), com foco em modernizar os endpoints e aprimorar a lógica de feedback ao usuário após o salvamento de um horário.

## Principais Alterações

### Backend (py/capim.py)

* **Renomeação de Endpoints:** Os endpoints de carregamento (`load2.cgi`) e salvamento (`save2.cgi`) foram renomeados para `/load` e `/store`, respectivamente. Isso pois as função de save e load no js não enviam mais como `load2.cgi` e `save2.cgi`:
```
self.save = function(identifier) {
        if (!identifier || identifier == "") {
            ui_logger.set_text("identifier invalido", "lightcoral");
            return;
        }

        let url = 'store/' + identifier; // ou let url = 'load + identifier;
[...]
```

* **Geração de Nome de Arquivo:** A função `encoded_fname` foi refatorada para aceitar o `identifier` diretamente e usar a codificação UTF-8 seguida de `.hex()` para gerar o nome do arquivo. Pelo mesmo motivo. Antes o identificar era esperado assim: `/save2.cgi?q=1234`. Porém, com o update para /store/id, o encodefname pode ser alterado para obter o identificador diretamente do path.

* **Tratamento de Requisição:** No endpoint `/store`, a leitura do corpo da requisição (`environ['wsgi.input']`) agora considera o `CONTENT_LENGTH` do ambiente WSGI.

* **Retorno:** O retorno de sucesso do endpoint `/store` foi ajustado para `b'OK'` (bytes).

### Frontend (js/main.js)

* **Lógica Condicional:** A mensagem de sucesso ('horário para "' + identifier + '" foi salvo'), a escrita de persistência (`persistence.write_id(identifier)`), e a atualização da flag de mudanças (`mudancas = false`) agora estão em um bloco `else`.
* **Motivação:** Isso garante que o feedback de sucesso e a atualização do estado ocorram apenas se o bloco de tratamento de erro anterior não for acionado, resolvendo uma falha na lógica de feedback do usuário, apresentada abaixo:
<img width="1416" height="405" alt="image" src="https://github.com/user-attachments/assets/21004ea6-682c-4b4d-9ca3-65602f858848" />


Não consegui rodar o matrufsc diretamente a ponto de testar a funcionalidade de salvar. Tive que fazer várias atualizações aqui que não faria sentido incluir no PR, pois acredito que isso seja devido principalmente à uma incompatibilidade entre as versões das bibliotecas que usei.